### PR TITLE
Update132

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,16 @@ This project uses an [Apache license](LICENSE). Be sure you're comfortable with 
 
 ## Review and merge process
 
+Original repository is at https://github.com/kelseyhightower/kubernetes-the-hard-way.
+
 Review and merge duties are managed by [@kelseyhightower](https://github.com/kelseyhightower). Expect some burden of proof for demonstrating the marginal value of adding new content to the tutorial.
 
 Here are some examples of the review and justification process:
 
 - [#208](https://github.com/kelseyhightower/kubernetes-the-hard-way/pull/208)
 - [#282](https://github.com/kelseyhightower/kubernetes-the-hard-way/pull/282)
+
+What he said.
 
 ## Notes on minutiae
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ The target audience for this tutorial is someone planning to support a productio
 
 Kubernetes The Hard Way guides you through bootstrapping a highly available Kubernetes cluster with end-to-end encryption between components and RBAC authentication.
 
-* [kubernetes](https://github.com/kubernetes/kubernetes) v1.29.1
-* [containerd](https://github.com/containerd/containerd) v1.7.13
-* [coredns](https://github.com/coredns/coredns) v1.11.1
-* [cni-plugins](https://github.com/containernetworking/plugins) v1.4.0
-* [etcd](https://github.com/etcd-io/etcd) v3.5.12
+* [kubernetes](https://github.com/kubernetes/kubernetes) v1.32.2
+* [containerd](https://github.com/containerd/containerd) v2.0.2
+* [coredns](https://github.com/coredns/coredns) v1.11.1 (v1.12.0 is latest but not updated here)
+* [cni-plugins](https://github.com/containernetworking/plugins) v1.6.2
+* [etcd](https://github.com/etcd-io/etcd) v3.5.18
 
 ## Labs
 

--- a/docs/02-client-tools.md
+++ b/docs/02-client-tools.md
@@ -9,8 +9,8 @@ The `cfssl` and `cfssljson` command line utilities will be used to provision a [
 On the **gateway-01** VM, download and install `cfssl` and `cfssljson`:
 
 ```bash
-  wget -q --show-progress --https-only --timestamping https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssl_1.6.4_linux_amd64 -O cfssl
-  wget -q --show-progress --https-only --timestamping https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssljson_1.6.4_linux_amd64  -O cfssljson
+  wget -q --show-progress --https-only --timestamping https://github.com/cloudflare/cfssl/releases/download/v1.6.5/cfssl_1.6.5_linux_amd64 -O cfssl
+  wget -q --show-progress --https-only --timestamping https://github.com/cloudflare/cfssl/releases/download/v1.6.5/cfssljson_1.6.5_linux_amd64  -O cfssljson
 ```
 
 ```bash
@@ -32,7 +32,7 @@ cfssl version
 > Output:
 
 ```bash
-Version: 1.3.4
+Version: 1.6.5
 Revision: dev
 Runtime: go1.13
 ```
@@ -44,7 +44,7 @@ cfssljson --version
 > Output:
 
 ```bash
-Version: 1.3.4
+Version: 1.6.5
 Revision: dev
 Runtime: go1.13
 ```
@@ -53,16 +53,26 @@ Runtime: go1.13
 
 The `kubectl` command line utility is used to interact with the Kubernetes API Server. On the **gateway-01** VM, download and install `kubectl` from the official release binaries:
 
+Following instructions at: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
+
 ```bash
-wget https://storage.googleapis.com/kubernetes-release/release/v1.29.1/bin/linux/amd64/kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+```
+
+Validate the binary.
+```bash
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
+```
+
+If valid, the output is:
+
+```
+kubectl: OK
 ```
 
 ```bash
-chmod +x kubectl
-```
-
-```bash
-sudo mv kubectl /usr/local/bin/
+sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 ```
 
 ### Verification install
@@ -76,8 +86,8 @@ kubectl version --client
 > Output:
 
 ```bash
-Client Version: v1.29.1
-Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
+Client Version: v1.32.2
+Kustomize Version: v5.5.0
 
 ```
 

--- a/docs/04-certificate-authority.md
+++ b/docs/04-certificate-authority.md
@@ -34,11 +34,11 @@ cat > ca-csr.json <<EOF
   },
   "names": [
     {
-      "C": "FR",
-      "L": "Rennes",
+      "C": "US",
+      "L": "New York",
       "O": "Kubernetes",
       "OU": "CA",
-      "ST": "Bretagne"
+      "ST": "NY"
     }
   ]
 }
@@ -72,11 +72,11 @@ cat > admin-csr.json <<EOF
   },
   "names": [
     {
-      "C": "FR",
-      "L": "Rennes",
+      "C": "US",
+      "L": "New York",
       "O": "system:masters",
       "OU": "Kubernetes The Hard Way",
-      "ST": "Bretagne"
+      "ST": "NY"
     }
   ]
 }
@@ -116,11 +116,11 @@ cat > worker-${id_instance}-csr.json <<EOF
   },
   "names": [
     {
-      "C": "FR",
-      "L": "Rennes",
+      "C": "US",
+      "L": "New York",
       "O": "system:nodes",
       "OU": "Kubernetes The Hard Way",
-      "ST": "Bretagne"
+      "ST": "NY"
     }
   ]
 }
@@ -163,11 +163,11 @@ cat > kube-controller-manager-csr.json <<EOF
   },
   "names": [
     {
-      "C": "FR",
-      "L": "Rennes",
+      "C": "US",
+      "L": "New York",
       "O": "system:kube-controller-manager",
       "OU": "Kubernetes The Hard Way",
-      "ST": "Bretagne"
+      "ST": "NY"
     }
   ]
 }
@@ -202,11 +202,11 @@ cat > kube-proxy-csr.json <<EOF
   },
   "names": [
     {
-      "C": "FR",
-      "L": "Rennes",
+      "C": "US",
+      "L": "New York",
       "O": "system:node-proxier",
       "OU": "Kubernetes The Hard Way",
-      "ST": "Bretagne"
+      "ST": "NY"
     }
   ]
 }
@@ -241,11 +241,11 @@ cat > kube-scheduler-csr.json <<EOF
   },
   "names": [
     {
-      "C": "FR",
-      "L": "Rennes",
+      "C": "US",
+      "L": "New York",
       "O": "system:kube-scheduler",
       "OU": "Kubernetes The Hard Way",
-      "ST": "Bretagne"
+      "ST": "NY"
     }
   ]
 }
@@ -286,11 +286,11 @@ cat > kubernetes-csr.json <<EOF
   },
   "names": [
     {
-      "C": "FR",
-      "L": "Rennes",
+      "C": "US",
+      "L": "New York",
       "O": "Kubernetes",
       "OU": "Kubernetes The Hard Way",
-      "ST": "Bretagne"
+      "ST": "NY"
     }
   ]
 }
@@ -330,11 +330,11 @@ cat > service-account-csr.json <<EOF
   },
   "names": [
     {
-      "C": "FR",
-      "L": "Rennes",
+      "C": "US",
+      "L": "New York",
       "O": "Kubernetes",
       "OU": "Kubernetes The Hard Way",
-      "ST": "Bretagne"
+      "ST": "NY"
     }
   ]
 }

--- a/docs/07-bootstrapping-etcd.md
+++ b/docs/07-bootstrapping-etcd.md
@@ -22,14 +22,14 @@ Download the official etcd release binaries from the [etcd](https://github.com/e
 
 ```bash
 wget -q --show-progress --https-only --timestamping \
-  "https://github.com/etcd-io/etcd/releases/download/v3.5.12/etcd-v3.5.12-linux-amd64.tar.gz"
+  "https://github.com/etcd-io/etcd/releases/download/v3.5.18/etcd-v3.5.18-linux-amd64.tar.gz"
 ```
 
 Extract and install the `etcd` server and the `etcdctl` command line utility:
 
 ```bash
-tar -xvf etcd-v3.5.12-linux-amd64.tar.gz
-sudo mv etcd-v3.5.12-linux-amd64/etcd* /usr/local/bin/
+tar -xvf etcd-v3.5.18-linux-amd64.tar.gz
+sudo mv etcd-v3.5.18-linux-amd64/etcd* /usr/local/bin/
 ```
 
 ### Configure the etcd Server

--- a/docs/08-bootstrapping-kubernetes-controllers.md
+++ b/docs/08-bootstrapping-kubernetes-controllers.md
@@ -28,10 +28,10 @@ Download the official Kubernetes release binaries:
 
 ```bash
 wget -q --show-progress --https-only --timestamping \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.29.1/bin/linux/amd64/kube-apiserver" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.29.1/bin/linux/amd64/kube-controller-manager" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.29.1/bin/linux/amd64/kube-scheduler" \
-  "https://storage.googleapis.com/kubernetes-release/release/v1.29.1/bin/linux/amd64/kubectl"
+  "https://dl.k8s.io/v1.32.2/bin/linux/amd64/kubectl" \
+  "https://dl.k8s.io/v1.32.2/bin/linux/amd64/kube-apiserver" \
+  "https://dl.k8s.io/v1.32.2/bin/linux/amd64/kube-controller-manager" \
+  "https://dl.k8s.io/v1.32.2/bin/linux/amd64/kube-scheduler"
 ```
 
 Install the Kubernetes binaries:

--- a/docs/09-bootstrapping-kubernetes-workers.md
+++ b/docs/09-bootstrapping-kubernetes-workers.md
@@ -47,13 +47,13 @@ sudo swapoff -a
 
 ```bash
 wget -q --show-progress --https-only --timestamping \
-  https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.29.0/crictl-v1.29.0-linux-amd64.tar.gz \
-  https://github.com/opencontainers/runc/releases/download/v1.1.12/runc.amd64 \
-  https://github.com/containernetworking/plugins/releases/download/v1.4.0/cni-plugins-linux-amd64-v1.4.0.tgz \
-  https://github.com/containerd/containerd/releases/download/v1.7.13/containerd-1.7.13-linux-amd64.tar.gz \
-  https://storage.googleapis.com/kubernetes-release/release/v1.29.1/bin/linux/amd64/kubectl \
-  https://storage.googleapis.com/kubernetes-release/release/v1.29.1/bin/linux/amd64/kube-proxy \
-  https://storage.googleapis.com/kubernetes-release/release/v1.29.1/bin/linux/amd64/kubelet
+  "https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.32.0/crictl-v1.32.0-linux-amd64.tar.gz" \
+  "https://github.com/opencontainers/runc/releases/download/v1.2.5/runc.amd64" \
+  "https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz" \
+  "https://github.com/containerd/containerd/releases/download/v2.0.2/containerd-2.0.2-linux-amd64.tar.gz" \
+  "https://dl.k8s.io/v1.32.2/bin/linux/amd64/kubectl" \
+  "https://dl.k8s.io/v1.32.2/bin/linux/amd64/kube-proxy" \
+  "https://dl.k8s.io/v1.32.2/bin/linux/amd64/kubelet"
 ```
 
 Create the installation directories:
@@ -72,9 +72,9 @@ Install the worker binaries:
 
 ```bash
 mkdir containerd
-tar -xvf crictl-v1.29.0-linux-amd64.tar.gz
-tar -xvf containerd-1.7.13-linux-amd64.tar.gz -C containerd
-sudo tar -xvf cni-plugins-linux-amd64-v1.4.0.tgz -C /opt/cni/bin/
+tar -xvf crictl-v1.32.0-linux-amd64.tar.gz
+tar -xvf containerd-2.0.2-linux-amd64.tar.gz -C containerd
+sudo tar -xvf cni-plugins-linux-amd64-v1.6.2.tgz -C /opt/cni/bin/
 sudo mv runc.amd64 runc
 chmod +x crictl kubectl kube-proxy kubelet runc
 sudo mv crictl kubectl kube-proxy kubelet runc /usr/local/bin/
@@ -89,7 +89,10 @@ Define the Pod CIDR range for the current node (different for each worker). Repl
 POD_CIDR=THE_POD_CIDR
 ```
 
-> Example for worker-0: 10.200.0.0/24
+> Example: 
+  * worker-0: 10.200.0.0/24
+  * worker-1: 10.200.1.0/24
+  * worker-2: 10.200.2.0/24
 
 Create the `bridge` network configuration file:
 

--- a/docs/11-pod-network-routes.md
+++ b/docs/11-pod-network-routes.md
@@ -32,7 +32,7 @@ ip route
 default via 192.168.8.1 dev ens18 proto static
 10.200.1.0/24 via 192.168.8.21 dev ens18
 10.200.2.0/24 via 192.168.8.22 dev ens18
-192.168.8.0/24 dev ens18 proto kernel scope link src 192.168.8.21
+192.168.8.0/24 dev ens18 proto kernel scope link src 192.168.8.20
 ```
 
 To make it persistent (if reboot), you need to edit your network configuration (depends on your Linux distribution).
@@ -51,7 +51,7 @@ network:
   ethernets:
     ens18:
       addresses:
-      - 192.168.8.10/24
+      - 192.168.8.20/24
       gateway4: 192.168.8.1
       nameservers:
         addresses:

--- a/docs/12-dns-addon.md
+++ b/docs/12-dns-addon.md
@@ -7,7 +7,7 @@ In this lab you will deploy the [DNS add-on](https://kubernetes.io/docs/concepts
 Get the CoreDNS yaml:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/DushanthaS/kubernetes-the-hard-way-on-proxmox/master/deployments/coredns.yaml
+kubectl apply -f https://raw.githubusercontent.com/chris-sanders-dot-org/kubernetes-the-hard-way-on-proxmox/master/deployments/coredns.yaml
 ```
 
 


### PR DESCRIPTION
Updated guide to install latest K8s: 1.32.2

Guide updated to use latest versions of all packages used, except CoreDNS.